### PR TITLE
Disable when current project doesn't use jest

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -7,5 +7,4 @@ decls
 
 [options]
 module.system=node
-unsafe.enable_getters_and_setters=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore

--- a/.flowconfig
+++ b/.flowconfig
@@ -8,3 +8,4 @@ decls
 [options]
 module.system=node
 suppress_comment= \\(.\\|\n\\)*\\$FlowIgnore
+module.ignore_non_literal_requires=true

--- a/lib/tester-jest.js
+++ b/lib/tester-jest.js
@@ -1,11 +1,30 @@
 'use babel';
 
 /* @flow */
+import fs from 'fs';
 import type { TextEditor } from 'atom';
 import * as jestRunner from './spawn-runner';
 
+let _hasProjectJest;
+
+export const hasProjectJest = () => _hasProjectJest;
+
 export function activate() {
   require('atom-package-deps').install();
+
+  _hasProjectJest = atom.project.rootDirectories
+    .map(dir => dir.path.concat('/package.json'))
+    .filter((pkgFile) => {
+      try {
+        fs.accessSync(pkgFile);
+        return true;
+      } catch (error) {
+        return false;
+      }
+    })
+    // eslint-disable-next-line import/no-dynamic-require
+    .map(pkg => Object.keys(require(pkg).devDependencies).find(pkgName => pkgName === 'jest'))
+    .reduce((output, jest) => !!jest, false);
 }
 
 export function deactivate() {
@@ -18,11 +37,13 @@ export function provideTester() {
     options: {},
     scopes: atom.config.get('tester-jest.scopes'),
     test(textEditor :TextEditor, additionalArgs :?string) {
+      if (!this._hasProjectJest) return [];
       // Note, a Promise may be returned as well!
       return jestRunner.run(textEditor, additionalArgs);
     },
     stop() {
       jestRunner.stop();
     },
+    _hasProjectJest,
   };
 }

--- a/package.json
+++ b/package.json
@@ -116,9 +116,9 @@
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.4.0",
-    "flow-bin": "false0.62.0",
+    "flow-bin": "0.62.0",
     "jest": "21.2.0",
-    "mock-fs": "false4.4.2",
+    "mock-fs": "4.4.2",
     "mock-require": "^2.0.2"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,10 @@
     "eslint-plugin-import": "2.7.0",
     "eslint-plugin-jsx-a11y": "6.0.2",
     "eslint-plugin-react": "7.4.0",
-    "jest": "21.2.0"
+    "flow-bin": "false0.62.0",
+    "jest": "21.2.0",
+    "mock-fs": "false4.4.2",
+    "mock-require": "^2.0.2"
   },
   "jest": {
     "testRegex": "\\.spec\\.(js|jsx)$",

--- a/spec/tester-jest-spec.js
+++ b/spec/tester-jest-spec.js
@@ -2,38 +2,81 @@
 
 /* @flow */
 import Promise from 'bluebird';
+import mockRequire from 'mock-require';
+import mockFs from 'mock-fs';
 import * as jestRunner from '../lib/spawn-runner';
 import { textEditor } from './fixtures';
-import { provideTester } from '../lib/tester-jest';
+import { provideTester, activate, hasProjectJest } from '../lib/tester-jest';
 
 describe('tester-jest', () => {
-  it('should provide tester name', () => {
-    expect(provideTester().name).toEqual('tester-jest');
+  describe('activate', () => {
+    beforeEach(() => {
+      mockRequire('atom-package-deps', { install() {} });
+    });
+
+    it('should set hasProjectJest to false if jest isn\'t provided in package.json', () => {
+      atom.project.rootDirectories
+        .map(dir => dir.path.concat('/package.json'))
+        .forEach((path) => {
+          mockRequire(path, { devDependencies: { nojest: '1.0' } });
+          mockFs({ [path]: {} });
+        });
+
+      activate();
+
+      expect(hasProjectJest()).toEqual(false);
+    });
+
+    it('should set hasProjectJest to true if jest is provided in package.json', () => {
+      atom.project.rootDirectories
+        .map(dir => dir.path.concat('/package.json'))
+        .forEach((path) => {
+          mockRequire(path, { devDependencies: { jest: '1.0' } });
+          mockFs({ [path]: {} });
+        });
+
+      activate();
+
+      expect(hasProjectJest()).toEqual(true);
+    });
   });
 
-  it('should provide tester scopes', () => {
-    const scopes = '**.spec.js';
-    atom.config.set('tester-jest.scopes', scopes);
-    expect(provideTester().scopes).toEqual(scopes);
-  });
+  describe('provideTester', () => {
+    it('should provide tester name', () => {
+      expect(provideTester().name).toEqual('tester-jest');
+    });
 
-  it('should provide test function and run project test if editor is empty', () => {
-    spyOn(jestRunner, 'run').andCallFake(() => Promise.resolve({ messages: [], output: '' }));
-    const result = provideTester().test();
-    expect(jestRunner.run).toHaveBeenCalledWith(undefined, undefined);
-    expect(result).toEqual(Promise.resolve({ messages: [], output: '' }));
-  });
+    it('should provide tester scopes', () => {
+      const scopes = '**.spec.js';
+      atom.config.set('tester-jest.scopes', scopes);
+      expect(provideTester().scopes).toEqual(scopes);
+    });
 
-  it('should provide test function and call "spawn-runner.run" if editor is not empty', () => {
-    spyOn(jestRunner, 'run').andCallFake(() => Promise.resolve({ messages: [], output: '' }));
-    const result = provideTester().test(textEditor);
-    expect(jestRunner.run).toHaveBeenCalledWith(textEditor, undefined);
-    expect(result).toEqual(Promise.resolve({ messages: [], output: '' }));
-  });
+    it('should provide test function and run project test if editor is empty', () => {
+      spyOn(jestRunner, 'run').andCallFake(() => Promise.resolve({ messages: [], output: '' }));
+      const result = { ...provideTester(), _hasProjectJest: true }.test();
+      expect(jestRunner.run).toHaveBeenCalledWith(undefined, undefined);
+      expect(result).toEqual(Promise.resolve({ messages: [], output: '' }));
+    });
 
-  it('should provide stop function and call "spawn-runner.stop"', () => {
-    spyOn(jestRunner, 'stop');
-    provideTester().stop();
-    expect(jestRunner.stop).toHaveBeenCalled();
+    it('should provide test function and call "spawn-runner.run" if editor is not empty', () => {
+      spyOn(jestRunner, 'run').andCallFake(() => Promise.resolve({ messages: [], output: '' }));
+      const result = { ...provideTester(), _hasProjectJest: true }.test(textEditor);
+      expect(jestRunner.run).toHaveBeenCalledWith(textEditor, undefined);
+      expect(result).toEqual(Promise.resolve({ messages: [], output: '' }));
+    });
+
+    it('should provide test function and not run project test if jest isn\'t provided', () => {
+      spyOn(jestRunner, 'run');
+      const result = { ...provideTester(), _hasProjectJest: false }.test();
+      expect(jestRunner.run).not.toHaveBeenCalledWith(undefined, undefined);
+      expect(result).toEqual([]);
+    });
+
+    it('should provide stop function and call "spawn-runner.stop"', () => {
+      spyOn(jestRunner, 'stop');
+      provideTester().stop();
+      expect(jestRunner.stop).toHaveBeenCalled();
+    });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,6 +517,12 @@ builtin-modules@^1.0.0, builtin-modules@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
+caller-id@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/caller-id/-/caller-id-0.1.0.tgz#59bdac0893d12c3871408279231f97458364f07b"
+  dependencies:
+    stack-trace "~0.0.7"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1161,6 +1167,10 @@ flat-cache@^1.2.1:
     del "^2.0.2"
     graceful-fs "^4.1.2"
     write "^0.2.1"
+
+flow-bin@false0.62.0:
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
 
 for-in@^1.0.1:
   version "1.0.2"
@@ -2181,6 +2191,16 @@ minimist@^1.1.1, minimist@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
+mock-fs@false4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.4.2.tgz#09dec5313f97095a450be6aa2ad8ab6738d63d6b"
+
+mock-require@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/mock-require/-/mock-require-2.0.2.tgz#1eaa71aad23013773d127dc7e91a3fbb4837d60d"
+  dependencies:
+    caller-id "^0.1.0"
+
 ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
@@ -2875,6 +2895,10 @@ sshpk@^1.7.0:
     jodid25519 "^1.0.0"
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
+
+stack-trace@~0.0.7:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This will prevent warnings/crashes when the plugin is enabled and the user opens a project that doesn't use jest. In this PR the plugin will only check package.json upon activation. A future improvement could be to listen for changes in package.json, so the user doesn't need to restart the project after installing jest. 